### PR TITLE
Refactor like and comment UI into reusable component

### DIFF
--- a/resources/views/components/like-comments.blade.php
+++ b/resources/views/components/like-comments.blade.php
@@ -1,0 +1,17 @@
+<div id="like-section-feed-{{ $post->id }}" class="my-2 ms-3 d-flex">
+    <div class="d-flex gap-1">
+        <button id="like-button-feed-{{ $post->id }}" onclick="toggleLike({{ $post->id }})">
+            <!-- Ikon Like -->
+            <i id="like-icon-feed-{{ $post->id }}"
+                class="{{ auth()->check() && $post->likes->contains(auth()->id()) ? 'fa-solid fa-heart fa-xl text-danger' : 'fa-regular fa-heart fa-xl' }}"></i>
+        </button>
+        <div data-bs-toggle="modal" data-bs-target="#showWhoLikeModal{{ $post->id }}">
+            <span id="like-count-feed-{{ $post->id }}">{{ $post->likes->count() }}
+                likes</span>
+        </div>
+    </div>
+    <div data-bs-toggle="modal" data-bs-target="#showPostModal{{ $post->id }}">
+        <i class="fa-regular fa-comment fa-xl ms-2"></i>
+        <span>{{ $post->comments->count() }} comments</span>
+    </div>
+</div>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -123,25 +123,7 @@
                             @endif
                         </div>
 
-                        <!-- Like dan Komentar -->
-                        <div id="like-section-feed-{{ $post->id }}" class="my-2 ms-3 d-flex">
-                            <div class="d-flex gap-1">
-                                <button id="like-button-feed-{{ $post->id }}"
-                                    onclick="toggleLike({{ $post->id }})">
-                                    <!-- Ikon Like -->
-                                    <i id="like-icon-feed-{{ $post->id }}"
-                                        class="{{ auth()->check() && $post->likes->contains(auth()->id()) ? 'fa-solid fa-heart fa-xl text-danger' : 'fa-regular fa-heart fa-xl' }}"></i>
-                                </button>
-                                <div data-bs-toggle="modal" data-bs-target="#showWhoLikeModal{{ $post->id }}">
-                                    <span id="like-count-feed-{{ $post->id }}">{{ $post->likes->count() }}
-                                        likes</span>
-                                </div>
-                            </div>
-                            <div data-bs-toggle="modal" data-bs-target="#showPostModal{{ $post->id }}">
-                                <i class="fa-regular fa-comment fa-xl ms-2"></i>
-                                <span>{{ $post->comments->count() }} comments</span>
-                            </div>
-                        </div>
+                        @include('components.like-comments')
 
                         <!-- Caption -->
                         <div data-bs-toggle="modal" data-bs-target="#showPostModal{{ $post->id }}">
@@ -157,32 +139,14 @@
                             </p>
                         </div>
 
-                        <!-- Like dan Komentar -->
-                        <div id="like-section-feed-{{ $post->id }}" class="my-2 ms-3 d-flex">
-                            <div class="d-flex gap-1">
-                                <button id="like-button-feed-{{ $post->id }}"
-                                    onclick="toggleLike({{ $post->id }})">
-                                    <!-- Ikon Like -->
-                                    <i id="like-icon-feed-{{ $post->id }}"
-                                        class="{{ auth()->check() && $post->likes->contains(auth()->id()) ? 'fa-solid fa-heart fa-xl text-danger' : 'fa-regular fa-heart fa-xl' }}"></i>
-                                </button>
-                                <div data-bs-toggle="modal" data-bs-target="#showWhoLikeModal{{ $post->id }}">
-                                    <span id="like-count-feed-{{ $post->id }}">{{ $post->likes->count() }}
-                                        likes</span>
-                                </div>
-                            </div>
-                            <div data-bs-toggle="modal" data-bs-target="#showPostModal{{ $post->id }}">
-                                <i class="fa-regular fa-comment fa-xl ms-2"></i>
-                                <span>{{ $post->comments->count() }} comments</span>
-                            </div>
-                        </div>
+                        @include('components.like-comments')
                     @endif
 
                     <!-- Form Komentar -->
                     <form action="{{ route('comments.store', $post->id) }}" method="POST" class="d-flex">
                         @csrf
                         <textarea id="comment-input" name="body" class="form-control form-control-sm" placeholder="Komentar . . ."
-                            style="width: 100%" rows="2"></textarea>
+                            style="width: 100%" rows="1"></textarea>
 
                         <input type="submit" value="Kirim" class="btn btn-sm btn-primary ms-2">
                     </form>

--- a/resources/views/pages/account/show.blade.php
+++ b/resources/views/pages/account/show.blade.php
@@ -10,6 +10,8 @@
     </style>
 @endpush
 @section('content')
+    @include('pages.post.edit')
+    @include('pages.post.show')
     <div class="container px-40">
         <!-- Header Profil -->
         <div class="d-flex align-items-start mb-4">
@@ -78,7 +80,8 @@
                     @foreach ($posts as $post)
                         @if ($post->media->isNotEmpty())
                             <div class="col-4 p-0">
-                                <a href="{{ route('posts.show', $post->id) }}" class="d-block h-100">
+                                <div data-bs-toggle="modal" data-bs-target="#showPostModal{{ $post->id }}"
+                                    class="d-block h-100">
                                     <div class="position-relative h-100" style="min-height: 350px; max-height: 350px;">
                                         @php
                                             $firstMedia = $post->media->first();
@@ -91,7 +94,7 @@
                                         <img src="{{ $imageUrl }}" alt="Post Media" class="img-fluid w-100 h-100"
                                             style="object-fit: cover;">
                                     </div>
-                                </a>
+                                </div>
                             </div>
                         @endif
                     @endforeach
@@ -158,28 +161,13 @@
                                         </div>
 
                                         <!-- Caption -->
-                                        <a href="{{ route('posts.show', $post->id) }}">
+                                        <div data-bs-toggle="modal" data-bs-target="#showPostModal{{ $post->id }}">
                                             <p class="mt-2">
                                                 {{ $post->caption }}
                                             </p>
-                                        </a>
-
-                                        <!-- Like dan Komentar -->
-                                        <div id="like-section-{{ $post->id }}" class="my-2 ms-3">
-                                            <button id="like-button-{{ $post->id }}"
-                                                onclick="toggleLike({{ $post->id }})">
-                                                <!-- Ikon Like -->
-                                                <i id="like-icon-{{ $post->id }}"
-                                                    class="{{ auth()->check() && $post->likes->contains(auth()->id()) ? 'fa-solid fa-heart fa-xl text-danger' : 'fa-regular fa-heart fa-xl' }}"></i>
-                                            </button>
-                                            <!-- Jumlah Like -->
-                                            <span id="like-count-{{ $post->id }}">{{ $post->likes->count() }}</span>
-                                            likes
-                                            <a href="{{ route('posts.show', $post->id) }}">
-                                                <i class="fa-regular fa-comment fa-xl ms-2"></i>
-                                                <span>{{ $post->comments->count() }} comments</span>
-                                            </a>
                                         </div>
+
+                                        @include('components.like-comments')
                                     </div>
                                 </div>
                             </div>

--- a/resources/views/pages/post/show.blade.php
+++ b/resources/views/pages/post/show.blade.php
@@ -158,27 +158,7 @@
 
                                     <!-- Fixed Bottom Section -->
                                     <div class="bottom-post flex-shrink-0 pt-3" style="border-top: 1px solid #dee2e6;">
-                                        <!-- Like Section -->
-                                        <div id="like-section-modal-{{ $post->id }}" class="my-2 d-flex">
-                                            <div class="d-flex gap-1">
-                                                <button id="like-button-feed-{{ $post->id }}"
-                                                    onclick="toggleLike({{ $post->id }})">
-                                                    <!-- Ikon Like -->
-                                                    <i id="like-icon-feed-{{ $post->id }}"
-                                                        class="{{ auth()->check() && $post->likes->contains(auth()->id()) ? 'fa-solid fa-heart fa-xl text-danger' : 'fa-regular fa-heart fa-xl' }}"></i>
-                                                </button>
-                                                <div data-bs-toggle="modal"
-                                                    data-bs-target="#showWhoLikeModal{{ $post->id }}">
-                                                    <span
-                                                        id="like-count-feed-{{ $post->id }}">{{ $post->likes->count() }}
-                                                        likes</span>
-                                                </div>
-                                            </div>
-                                            <a href="{{ route('posts.show', $post->id) }}">
-                                                <i class="fa-regular fa-comment fa-xl ms-2"></i>
-                                                <span>{{ $post->comments->count() }} comments</span>
-                                            </a>
-                                        </div>
+                                        @include('components.like-comments')
 
                                         <!-- Comment Form -->
                                         <form action="{{ route('comments.store', $post->id) }}" method="POST"
@@ -290,27 +270,7 @@
                                     <!-- Fixed Bottom Section -->
                                     <div class="bottom-post flex-shrink-0 pt-3"
                                         style="border-top: 1px solid #dee2e6;">
-                                        <!-- Like Section -->
-                                        <div id="like-section-modal-{{ $post->id }}" class="my-2 d-flex">
-                                            <div class="d-flex gap-1">
-                                                <button id="like-button-feed-{{ $post->id }}"
-                                                    onclick="toggleLike({{ $post->id }})">
-                                                    <!-- Ikon Like -->
-                                                    <i id="like-icon-feed-{{ $post->id }}"
-                                                        class="{{ auth()->check() && $post->likes->contains(auth()->id()) ? 'fa-solid fa-heart fa-xl text-danger' : 'fa-regular fa-heart fa-xl' }}"></i>
-                                                </button>
-                                                <div data-bs-toggle="modal"
-                                                    data-bs-target="#showWhoLikeModal{{ $post->id }}">
-                                                    <span
-                                                        id="like-count-feed-{{ $post->id }}">{{ $post->likes->count() }}
-                                                        likes</span>
-                                                </div>
-                                            </div>
-                                            <a href="{{ route('posts.show', $post->id) }}">
-                                                <i class="fa-regular fa-comment fa-xl ms-2"></i>
-                                                <span>{{ $post->comments->count() }} comments</span>
-                                            </a>
-                                        </div>
+                                        @include('components.like-comments')
 
                                         <!-- Comment Form -->
                                         <form action="{{ route('comments.store', $post->id) }}" method="POST"

--- a/resources/views/snapee.blade.php
+++ b/resources/views/snapee.blade.php
@@ -1,6 +1,7 @@
 @extends('layouts.app')
 @section('content')
     @include('pages.post.edit')
+    @include('pages.post.show')
     <div class="row">
         <!-- Kolom Utama (Feed Postingan) -->
         <div class="col-8 ms-5">
@@ -93,20 +94,7 @@
                         </div>
                     </a>
 
-                    <!-- Like dan Komentar -->
-                    <div id="like-section-{{ $post->id }}" class="my-2 ms-3">
-                        <button id="like-button-{{ $post->id }}" onclick="toggleLike({{ $post->id }})">
-                            <!-- Ikon Like -->
-                            <i id="like-icon-{{ $post->id }}"
-                                class="{{ auth()->check() && $post->likes->contains(auth()->id()) ? 'fa-solid fa-heart fa-xl text-danger' : 'fa-regular fa-heart fa-xl' }}"></i>
-                        </button>
-                        <!-- Jumlah Like -->
-                        <span id="like-count-{{ $post->id }}">{{ $post->likes->count() }}</span> likes
-                        <a href="{{ route('posts.show', $post->id) }}">
-                            <i class="fa-regular fa-comment fa-xl ms-2"></i>
-                            <span>{{ $post->comments->count() }} comments</span>
-                        </a>
-                    </div>
+                    @include('components.like-comments')
 
                     <!-- Caption -->
                     <a href="{{ route('posts.show', $post->id) }}">

--- a/resources/views/textee.blade.php
+++ b/resources/views/textee.blade.php
@@ -1,6 +1,7 @@
 @extends('layouts.app')
 @section('content')
     @include('pages.post.edit')
+    @include('pages.post.show')
     <div class="row">
         <!-- Kolom Utama (Feed Postingan) -->
         <div class="col-8 ms-5">
@@ -64,20 +65,7 @@
                         </p>
                     </a>
 
-                    <!-- Like dan Komentar -->
-                    <div id="like-section-{{ $post->id }}" class="my-2 ms-3">
-                        <button id="like-button-{{ $post->id }}" onclick="toggleLike({{ $post->id }})">
-                            <!-- Ikon Like -->
-                            <i id="like-icon-{{ $post->id }}"
-                                class="{{ auth()->check() && $post->likes->contains(auth()->id()) ? 'fa-solid fa-heart fa-xl text-danger' : 'fa-regular fa-heart fa-xl' }}"></i>
-                        </button>
-                        <!-- Jumlah Like -->
-                        <span id="like-count-{{ $post->id }}">{{ $post->likes->count() }}</span> likes
-                        <a href="{{ route('posts.show', $post->id) }}">
-                            <i class="fa-regular fa-comment fa-xl ms-2"></i>
-                            <span>{{ $post->comments->count() }} comments</span>
-                        </a>
-                    </div>
+                    @include('components.like-comments')
 
                     <!-- Form Komentar -->
                     <form action="{{ route('comments.store', $post->id) }}" method="POST" class="d-flex">


### PR DESCRIPTION
Extracted the like and comment section into a new Blade component (like-comments.blade.php) and replaced duplicated markup with @include('components.like-comments') across multiple views. This improves code maintainability and consistency for the like/comment UI.